### PR TITLE
Brew directory and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Suggest alternate spellings for a word:
     $ gem install ffi-hunspell
     
 
-* Download dictionaries (you can find some on the [OpenOffice Archive](http://archive.services.openoffice.org/pub/mirror/OpenOffice.org/contrib/dictionaries) 
+* Download dictionaries (you can find some on the [OpenOffice Archive](http://archive.services.openoffice.org/pub/mirror/OpenOffice.org/contrib/dictionaries))
 * (Unzip them and) copy files with `.aff` and `.dic` into one of [these directories](lib/ffi/hunspell/hunspell.rb#L65-82)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Suggest alternate spellings for a word:
 
     $ gem install ffi-hunspell
     
-
 * Download dictionaries (you can find some on the [OpenOffice Archive](http://archive.services.openoffice.org/pub/mirror/OpenOffice.org/contrib/dictionaries))
 * (Unzip them and) copy files with `.aff` and `.dic` into one of [these directories](lib/ffi/hunspell/hunspell.rb#L65-82)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Suggest alternate spellings for a word:
 ## Install
 
     $ gem install ffi-hunspell
+    
+
+* Download dictionaries (you can find some on the [OpenOffice Archive](http://archive.services.openoffice.org/pub/mirror/OpenOffice.org/contrib/dictionaries) 
+* (Unzip them and) copy files with `.aff` and `.dic` into one of [these directories](lib/ffi/hunspell/hunspell.rb#L65-82)
 
 ## License
 

--- a/lib/ffi/hunspell/hunspell.rb
+++ b/lib/ffi/hunspell/hunspell.rb
@@ -75,7 +75,10 @@ module FFI
       '/usr/share/myspell',
       # Mac Ports
       '/opt/local/share/hunspell',
-      '/opt/share/hunspell'
+      '/opt/share/hunspell',
+      # Homebrew
+      '/Library/Spelling',
+      '~/Library/Spelling'
     ]
 
     #


### PR DESCRIPTION
* Add README information on where to find dictionaries and how to install them
* Support homebrew suggested directories for dictionaries (as specified in their caveats pasted below)

> Dictionary files (*.aff and *.dic) should be placed in ~/Library/Spelling/ or /Library/Spelling/.  Homebrew itself provides no dictionaries for Hunspell, but you can download compatible dictionaries from other sources, such as https://wiki.openoffice.org/wiki/Dictionaries .