### PR TITLE
Include directories with dictionaries for brew-installed hunspell by default

### DIFF
--- a/lib/ffi/hunspell/hunspell.rb
+++ b/lib/ffi/hunspell/hunspell.rb
@@ -68,6 +68,9 @@ module FFI
     KNOWN_DIRECTORIES = [
       # User
       File.join(Gem.user_home,USER_DIR),
+      # OS X brew-instlled hunspell
+      File.join(Gem.user_home,'Library/Spelling'),
+      '/Library/Spelling',
       # Debian
       '/usr/local/share/myspell/dicts',
       '/usr/share/myspell/dicts',


### PR DESCRIPTION
As per `brew install hunspell` output:
Dictionary files (*.aff and *.dic) should be placed in
~/Library/Spelling/ or /Library/Spelling/.