### PR TITLE
Update to include hunspell-1.4

### DIFF
--- a/lib/ffi/hunspell/hunspell.rb
+++ b/lib/ffi/hunspell/hunspell.rb
@@ -5,6 +5,7 @@ module FFI
     extend FFI::Library
 
     ffi_lib [
+      'hunspell-1.4', 'libhunspell-1.4.so.0',
       'hunspell-1.3', 'libhunspell-1.3.so.0',
       'hunspell-1.2', 'libhunspell-1.2.so.0'
     ]


### PR DESCRIPTION
The current release of hunspell is [1.4.1](https://github.com/hunspell/hunspell/releases/tag/v1.4.1), so we should update the gem to support it (especially as those on macs will automatically get this version via ```brew update``` && ```brew install```).