### PR TITLE
Add Hunspell 1.4.1

### DIFF
--- a/lib/ffi/hunspell/hunspell.rb
+++ b/lib/ffi/hunspell/hunspell.rb
@@ -5,6 +5,7 @@ module FFI
     extend FFI::Library
 
     ffi_lib [
+      'hunspell-1.4.1', 'libhunspell-1.4.1.so.0',
       'hunspell-1.4', 'libhunspell-1.4.so.0',
       'hunspell-1.3', 'libhunspell-1.3.so.0',
       'hunspell-1.2', 'libhunspell-1.2.so.0'


### PR DESCRIPTION
Homebrew now installs hunspell 1.4.1. This PR adds support for the latest version.