### PR TITLE
Update to include hunspell-1.5

### DIFF
--- a/lib/ffi/hunspell/hunspell.rb
+++ b/lib/ffi/hunspell/hunspell.rb
@@ -5,6 +5,7 @@ module FFI
     extend FFI::Library
 
     ffi_lib [
+      'hunspell-1.5', 'libhunspell-1.5.so.0',
       'hunspell-1.4', 'libhunspell-1.4.so.0',
       'hunspell-1.3', 'libhunspell-1.3.so.0',
       'hunspell-1.2', 'libhunspell-1.2.so.0'


### PR DESCRIPTION
Hunspell is currently on release 1.5.4, so this will allow the gem to support the latest.
This is especially useful for mac users who have hunspell installed through homebrew and update regularly.